### PR TITLE
Remove the ssh port number from URL.

### DIFF
--- a/plugin/fugitive-gitea.vim
+++ b/plugin/fugitive-gitea.vim
@@ -20,6 +20,9 @@ function! s:giteaserver_url(opts, ...) abort
     return ''
   endif
 
+  if match(a:opts.remote, 'ssh://') >= 0
+      let repo = substitute(repo, ':\d\+', '', '')
+  endif
 
   if index(domains, 'http://' . matchstr(repo, '^[^:/]*')) >= 0
     let root = 'http://'.repo


### PR DESCRIPTION
Hi,

Thank you for the awesome plugin.
If a remote repository URL contains an ssh port (e.g. ssh://git@git.foobar.com:10022/foo/bar.com.git), I found the opened/copied URL includes the port number.

What this pull-request does is to remove the ssh port from the URL.

Thanks,